### PR TITLE
The converter should enable QField feature form's wizard mode to more closely match other XLSForm-compatible apps (ODK, Kobo, etc.)

### DIFF
--- a/src/xlsform2qgis/converter.py
+++ b/src/xlsform2qgis/converter.py
@@ -1782,7 +1782,7 @@ class XLSFormConverter(QObject):
         self.output_project.writeEntry("qfieldsync", "initialMapMode", "digitize")
 
         # Turn the QField feature form wizard mode on
-        self.output_project.writeEntry(
+        self.output_project.writeEntryBool(
             "qfieldsync", "featureFormWizardModeEnabled", True
         )
 

--- a/src/xlsform2qgis/converter.py
+++ b/src/xlsform2qgis/converter.py
@@ -1781,6 +1781,11 @@ class XLSFormConverter(QObject):
         # Set QField state to digitize when first opening the generated project
         self.output_project.writeEntry("qfieldsync", "initialMapMode", "digitize")
 
+        # Turn the QField feature form wizard mode on
+        self.output_project.writeEntry(
+            "qfieldsync", "featureFormWizardModeEnabled", True
+        )
+
         if self.output_project.crs().authid() == "EPSG:3857":
             display_settings = self.output_project.displaySettings()
 


### PR DESCRIPTION
Relevant QField PR: https://github.com/opengisch/QField/pull/7316

Basically, the vast majority of people who have used XLSForm surveys before would have done so using ODK or Kobo, both of which have a page/wizard approach to their form. 

By turning this on, we'll end up generating projects that more closely match expectations.